### PR TITLE
Use of qw(...) as parentheses is deprecated

### DIFF
--- a/lib/Gitalist/Controller/Fragment/Ref.pm
+++ b/lib/Gitalist/Controller/Fragment/Ref.pm
@@ -16,7 +16,7 @@ sub base : Chained('/fragment/repository/find') PathPart('') CaptureArgs(0) {}
 sub _diff {
     my ($self, $c) = @_;
     my %diff_args = ( patch => 1 );
-    foreach my $arg qw/filename parent/ {
+    foreach my $arg (qw/filename parent/) {
         if (defined $c->stash->{$arg}) {
             $diff_args{$arg} = $c->stash->{$arg};
         };


### PR DESCRIPTION
Avoid "Use of qw(...) as parentheses is deprecated" warning with perl-5.14
