### PR TITLE
Syntax hi-lighting is currently limited to 8K files and smaller

### DIFF
--- a/lib/Gitalist/View/SyntaxHighlight.pm
+++ b/lib/Gitalist/View/SyntaxHighlight.pm
@@ -19,7 +19,7 @@ sub render {
     my ($self, $c, $blob, $args) = @_;
 
     # Don't bother with anything over 64kb, it'll be tragically slow.
-    return encode_entities $blob if length $blob > 8192;
+    return encode_entities $blob if length $blob > 1048576;
     
     my $lang = $args->{language};
 


### PR DESCRIPTION
This would increase the allowed size to 1MB.
