### PR TITLE
utf-8 in description files

### DIFF
--- a/lib/Gitalist/Git/Repository.pm
+++ b/lib/Gitalist/Git/Repository.pm
@@ -218,6 +218,7 @@ class Gitalist::Git::Repository with (Gitalist::Git::HasUtils, Gitalist::Git::Se
         my $description = "";
         eval {
             $description = $self->path->file('description')->slurp;
+            utf8::decode($description);
             chomp $description;
         };
         $description = "Unnamed repository, edit the .git/description file to set a description"


### PR DESCRIPTION
Gitalist treated utf-8 encoded description files as latin-1, turning µbot into Âµbot for my µbot repo at http://koekblik.kaarsemaker.net. This one-line patch fixes that.
