### PR TITLE
Snapshot improvements

### DIFF
--- a/ISSUES
+++ b/ISSUES
@@ -4,4 +4,3 @@
 * Gitweb compat URIs are borked - there were some I just wholesale ripped out. Put back..
 * Sort out commitdiff so conflicted merges have an equivalent display to gitweb (d7f39bebabeb31ce9a7b4f1b6f3db9f391b78c3e as a reference)
 * Need to sanitise the input ...
-* The snapshot action does not properly support tgz - requests for this format will receive a tar.  tbz2 is not supported at all (yet).

--- a/gitalist.conf
+++ b/gitalist.conf
@@ -20,3 +20,8 @@ sitename "A Gitalist"
 <patches>
   max = 16
 </patches>
+
+<snapshot>
+  format = tar.bz2
+  tmpdir = /tmp/gitalist/snapshot
+</snapshot>

--- a/lib/Gitalist/Controller/Ref.pm
+++ b/lib/Gitalist/Controller/Ref.pm
@@ -49,15 +49,18 @@ Provides a snapshot of a given commit.
 
 sub snapshot : Chained('find') PathPart('snapshot') Args() {
     my ($self, $c, $format) = @_;
-    $format ||= 'tgz';
+    $format ||= Gitalist->config->{snapshot}{format} || "tar.bz2";
     my @snap = $c->stash->{Repository}->snapshot(
         sha1 => $c->stash->{Commit}->sha1,
         format => $format
     );
     $c->response->status(200);
-    $c->response->headers->header( 'Content-Disposition' =>
-                                       "attachment; filename=$snap[0]");
-    $c->response->body($snap[1]);
+    $c->response->content_type($snap[0]);
+    $c->response->content_length(-s $snap[2]);
+    $c->response->headers->header('Content-Disposition' =>
+                                       "attachment; filename=$snap[1]");
+    open(my $fh, '<', $snap[2]);
+    $c->response->body($fh);
 }
 
 =head2 patch

--- a/root/fragment/repository/shortlog.tt2
+++ b/root/fragment/repository/shortlog.tt2
@@ -33,6 +33,7 @@
  		<a href="[% c.uri_for_action("/ref/commit", [Repository.name, line.sha1]) %]" title="Commit details" class="button commit">commit</a>
  		<a href="[% c.uri_for_action("/ref/diff_fancy", [Repository.name, line.sha1]) %]" title="Commit difference" class="button diff">commitdiff</a>
  		<a href="[% c.uri_for_action("/ref/tree", [Repository.name, line.sha1]) %]" title="Tree" class="button tree">tree</a>
+ 		<a href="[% c.uri_for_action("/ref/snapshot", [Repository.name, line.sha1]) %]" title="Snapshot" class="button snapshot">snapshot</a>
 	</td>
 </tr>
 [% END %]

--- a/root/static/css/core.css
+++ b/root/static/css/core.css
@@ -258,6 +258,9 @@ a.longlog{
 a.blob{
 	background:transparent url([% c.uri_for('/static/i/icons/blob.png') %]) no-repeat;
 }
+a.snapshot{
+	background:transparent url([% c.uri_for('/static/i/icons/blob.png') %]) no-repeat;
+}
 a.blame{
 	background:transparent url([% c.uri_for('/static/i/icons/blame.png') %]) no-repeat;
 }
@@ -444,7 +447,7 @@ BUT the final width needs to be set with javascript based on the parent element 
 */
 
 .action-list{
-	width:120px;
+	width:160px;
 }
 
 .diff-tree{


### PR DESCRIPTION
- Snapshots are now stored on disk so they can be reused, tmpwatch can
  be used to clean up
- .tar.{gz,xz,bz2} snapshots are now supported
- Snapshot dir and format are configurable in the gitalist config
- shortlog/longlog now contain links to snapshots, defaulting to bz2
- Use the abbreviated sha1 in the snapshot filename and directory name
  like gitweb does
