### PR TITLE
Stop calling tags branches

### DIFF
--- a/root/fragment/repository/heads.tt2
+++ b/root/fragment/repository/heads.tt2
@@ -3,7 +3,7 @@
 <tr class="header">
    <[% cell %]>HEAD</[% cell %]>
    <[% cell %]>Last change</[% cell %]>
-   <[% cell %]>Branch</[% cell %]>
+   <[% cell %]>[% headtype || "Branch" %]</[% cell %]>
    <[% cell %]>Actions</[% cell %]>
 </tr>
 [% END %]

--- a/root/fragment/repository/tags.tt2
+++ b/root/fragment/repository/tags.tt2
@@ -1,1 +1,1 @@
-[% INCLUDE 'fragment/repository/heads.tt2' heads = tags %]
+[% INCLUDE 'fragment/repository/heads.tt2' heads = tags headtype="Tag" %]


### PR DESCRIPTION
In the repository overview tags were called branches, that's not right :)
