### PR TITLE
Stop breaking trees when submodules are encountered

### DIFF
--- a/lib/Gitalist/Git/Object/HasTree.pm
+++ b/lib/Gitalist/Git/Object/HasTree.pm
@@ -16,6 +16,8 @@ role Gitalist::Git::Object::HasTree {
         my @ret;
         for my $line (split /\0/, $output) {
             my ($mode, $type, $object, $file) = split /\s+/, $line, 4;
+            # Ignore commits, these represent submodules
+            next if $type eq 'commit';
             my $class = 'Gitalist::Git::Object::' . ucfirst($type);
             push @ret, $class->new( mode => oct $mode,
                                     type => $type,


### PR DESCRIPTION
For projects that contain submodules, ls-tree also lists the commits of
these, like:

dennis@lightning:~/code/Diamond$ git ls-tree HEAD
100644 blob 76548fb89c2c220d43759b40848600a16cfe65ea    .gitignore
100644 blob c2c5e7f9ad41d2a6bf49dcfe2a18c67f1b7264d3    .gitmodules
100644 blob 159d72c1edf6e0e227b0c1dda86aa08c307468df    LICENSE
100644 blob 3ce75ca4a98adbc6b1cdf68797b6b9328bf112cc    MANIFEST.in
100644 blob 588e2ba64d1968ecf949325cab4b1bfaf60caf75    Makefile
100644 blob 974a51cd30c73dc4fa5083252902b5596cbdeec8    README.md
040000 tree e69b70cc3f14491f167b3edd1561279344267b89    bin
040000 tree 10b76bbf7f6900e53916bf52c651b048569de46c    conf
040000 tree 90be53cbef1f3b6167a2b24f59365e94ce6cd989    debian
160000 commit 69c721d6d71b1a471e945bf680773467ee2c551e  docs
040000 tree daa6b06e1917938c2e939bbcd1d7b451e290b680    rpm
100644 blob 9046e2354860cb14b2ade3159c20e5245013a238    setup.cfg
100755 blob 0a4a2748cc2bb61685d5535d5a6557854153e7c0    setup.py
040000 tree 4b95cf8a722b456382abbd025476c87f87a97043    src
100644 blob a375d7dbdb98e15dc5021c0c5e4cb9757fcc0273    test.py
100644 blob 13f3e59423a6f49d89527b9e9a2050fb79d0025f    test.watchr

Gitalist would choke on those because these commits are commits from the
submodule's repository, not itself. So we should ignore them.
