### PR TITLE
The branch selector now sends you to the correct url

### DIFF
--- a/root/static/js/site.js
+++ b/root/static/js/site.js
@@ -47,7 +47,7 @@ function uriFor(action, sha1) {
 function switchBranch() {
     var branch = jQuery('#branch-list').val(),
         action = branch != '...' ? 'current' : 'heads';
-    document.location.href = uriFor(action, branch);
+    document.location.href = uriFor(action, escape(branch).replace('/', '%2F'));
 }
 
 function compareDiffs(){


### PR DESCRIPTION
It used to not escape the branch name, so branches like
seveas/branch_selector_fix were not really reachable via the selector
